### PR TITLE
Allow NIC to be set by VM_NIC env var with e1000 as the default

### DIFF
--- a/vbox.sh
+++ b/vbox.sh
@@ -124,7 +124,7 @@ createVM() {
       --disk $_iso \
       --disk path=$_vdi,format=qcow2,bus=${VM_DISK:-virtio} \
       --os-variant=$_ostype \
-      --network network=default,model=e1000 \
+      --network network=default,model=${VM_NIC:-e1000} \
       --graphics vnc,listen=0.0.0.0 \
       --noautoconsole  --import --machine virt --noacpi --boot loader=$__LOADER
     else
@@ -136,7 +136,7 @@ createVM() {
       --disk path=$_vdi,format=qcow2,bus=${VM_DISK:-virtio} \
       --cdrom $_iso \
       --os-variant=$_ostype \
-      --network network=default,model=e1000 \
+      --network network=default,model=${VM_NIC:-e1000} \
       --graphics vnc,listen=0.0.0.0 \
       --noautoconsole  --import --machine virt --noacpi --boot loader=$__LOADER
     fi
@@ -150,7 +150,7 @@ createVM() {
     --disk path=$_vdi,format=qcow2,bus=${VM_DISK:-virtio} \
     --cdrom $_iso \
     --os-variant=$_ostype \
-    --network network=default,model=e1000 \
+    --network network=default,model=${VM_NIC:-e1000} \
     --graphics vnc,listen=0.0.0.0 \
     --noautoconsole  --import
   fi
@@ -184,7 +184,7 @@ createVMFromVHD() {
     --arch ${VM_ARCH} \
     --disk $_vhd,format=qcow2,bus=${VM_DISK:-virtio} \
     --os-variant=$_ostype \
-    --network network=default,model=e1000 \
+    --network network=default,model=${VM_NIC:-e1000} \
     --graphics vnc,listen=0.0.0.0 \
     --noautoconsole  --import --machine virt --noacpi --boot loader=$__LOADER
 
@@ -196,7 +196,7 @@ createVMFromVHD() {
     --arch ${VM_ARCH:-x86_64} \
     --disk $_vhd,format=qcow2,bus=${VM_DISK:-virtio} \
     --os-variant=$_ostype \
-    --network network=default,model=e1000 \
+    --network network=default,model=${VM_NIC:-e1000} \
     --graphics vnc,listen=0.0.0.0 \
     --noautoconsole  --import
 
@@ -244,7 +244,7 @@ importVM() {
     --arch "$VM_ARCH" \
     --disk $_ova,format=qcow2,bus=${VM_DISK:-virtio} \
     --os-variant=$_ostype \
-    --network network=default,model=e1000 \
+    --network network=default,model=${VM_NIC:-e1000} \
     --graphics vnc,listen=0.0.0.0 \
     --noautoconsole  --import --check all=off --machine virt --noacpi --boot loader=$__LOADER
   else
@@ -255,7 +255,7 @@ importVM() {
     --arch ${VM_ARCH:-x86_64} \
     --disk $_ova,format=qcow2,bus=${VM_DISK:-virtio} \
     --os-variant=$_ostype \
-    --network network=default,model=e1000 \
+    --network network=default,model=${VM_NIC:-e1000} \
     --graphics vnc,listen=0.0.0.0 \
     --noautoconsole  --import  --check all=off
   fi


### PR DESCRIPTION
I've been using vmactions OpenBSD and FreeBSD VM's for testing of openjdk's bsd-port project. I've noticed intermittent network failures with the OpenBSD VM. For example, occasionally pkg_add fails due to networking problems, other times the network connection to the VM is completely lost. Reviewing these issues with other OpenBSD developers, it was pointed out the e1000/em0 nic does not work well in QEMU and the virtio/vio0 nic is the correct one to use for network stability.

I have tested switching to virtio with vmactions for OpenBSD 7.7 and 7.8 and it does work and so far has been stable for me. The first step in supporting it is to allow the NIC model to be overridden with e1000 as the default. This is similar to VM_DISK. Next, exports need to be added to base-vm and base-builder for VM_NIC and finally the OpenBSD conf files for 7.7 and 7.8 would get VM_NIC="virtio" added to them in openbsd-builder and rebuilt. 

Please consider adding this feature to vbox so openbsd-builder can switch to virtio for networking.