### PR TITLE
Two aarch64 fixes

### DIFF
--- a/vbox.sh
+++ b/vbox.sh
@@ -242,8 +242,8 @@ importVM() {
   if [ "$VM_ARCH" = "aarch64" ] || [ "$VM_ARCH" = "riscv64" ]; then
     $_SUDO_VIR_ virt-install \
     --name $_osname \
-    --memory 6144 \
-    --vcpus ${VM_CPU:-2} \
+    --memory $_mem \
+    --vcpus $_cpu \
     --arch "$VM_ARCH" \
     --disk $_ova,format=qcow2,bus=${VM_DISK:-virtio} \
     --os-variant=$_ostype \

--- a/vbox.sh
+++ b/vbox.sh
@@ -74,7 +74,7 @@ EOF
   fi
   mkdir -p "$HOME/.ssh"
   chmod 700 "$HOME/.ssh"
-  sudo chmod o+rx $HOME
+  sudo chmod 755 $HOME
 }
 
 


### PR DESCRIPTION
Two fixes for aarch64:

- When using ubuntu-latest-arm as a runner for openbsd-vm with arch: aarch64, the vm appears to not start. The VM starts fine but can't ssh back to the runner because the $HOME dir permissions are too permissive by default. 

`ls -l $HOME
drwxrwxrwx 12 runner runner 4096 Oct 29 20:28 /home/runner`

Which results in sshd on the runner denying the use of the authorized_keys file:

`Authentication refused: bad ownership or modes for directory /home/runner`

Setting $HOME to mode 755 corrects this issue and allows ubuntu-latest-arm to be set as the runner for openbsd with aarch64 vm. The VM performance is still bad because the arm kernel that comes with the runner appears to not support kvm yet, but at least it works. It should work for the other OS's too.

- The user supplied memory and cpu count in yml are ignored by vbox.sh for aarch64 and riscv64. Fix this by using the supplied values.