### PR TITLE
Work-around vncdotool's issues with special characters 

### DIFF
--- a/vbox.sh
+++ b/vbox.sh
@@ -808,7 +808,15 @@ inputFile() {
     string "nc  192.168.122.1 64342 | sh"
     input "$_osname" "enter"
   else
-    vncdotool --force-caps  --delay=100  typefile "$_file"
+    # work-around vncdotool's issues with special charecters
+    # by sending the file 1 chars at a time
+    # https://github.com/sibson/vncdotool/issues/269
+    while IFS= read -r line; do
+      for (( i=0; i<${#line}; i++ )); do
+        vncdotool --force-caps type "${line:i:1}"
+      done
+      vncdotool key enter
+    done < "$_file"
   fi
 
 }


### PR DESCRIPTION
by sending the file 1 char at a time:
https://github.com/sibson/vncdotool/issues/269

Most likely the issue is the bug above, but there is a second part to this with the VM being slower like aarch64 trips the bug. I tried sending 5 chars at a time and that didn't stablize it. It takes 7 minutes to send the enablessh.local file over this way but it appears reliable. There could be better ways to fix this too - just sending this out there as an option for you.