### PR TITLE
Use qemu-img convert to create sparse final image.

### DIFF
--- a/vbox.sh
+++ b/vbox.sh
@@ -791,7 +791,8 @@ exportOVA() {
 
   _sor="$($_SUDO_VIR_  virsh domblklist $_osname | grep -E -o '/.*qcow2')"
   echo "$_sor"
-  sudo zstd -c "$_sor" | split -b 2000M -d -a 1 - "$_ova.zst."
+  sudo qemu-img convert -O qcow2 -o preallocation=off "$_sor" "$_ova"
+  sudo zstd -c "$_ova" | split -b 2000M -d -a 1 - "$_ova.zst."
   ls -lah
   sudo mv "$_ova.zst.0" "$_ova.zst"
   sudo chmod +r ${_ova}.zst*


### PR DESCRIPTION
This will omit any no longer used data from the intermediate image, in particular any that has been zeroed out, creating a smaller final image. This allows builders to zero out swap space and unused filesystem space, which combined with this can result in significantly smaller final images.

Something similar was previously done in f640fe2 then reverted in b405b28. The reason for the revert was not stated, but my guess is it was because it turned on qcow2 zlib compression.  This would have rendered the more effective zstd compression completely ineffective and probably increased the final image size.