### PR TITLE
Add discard=unmap and detect_zeroes=discard.

### DIFF
--- a/vbox.sh
+++ b/vbox.sh
@@ -132,6 +132,8 @@ createVM() {
       --arch "$VM_ARCH" \
       --disk $_iso \
       --disk path=$_vdi,format=qcow2,bus=${VM_DISK:-virtio} \
+      --xml ./devices/disk[2]/driver/@discard=unmap \
+      --xml ./devices/disk[2]/driver/@detect_zeroes=unmap \
       --os-variant=$_ostype \
       --network network=default,model=${VM_NIC:-e1000} \
       --graphics vnc,listen=0.0.0.0 \
@@ -144,6 +146,8 @@ createVM() {
       --vcpus ${VM_CPU:-2} \
       --arch "$VM_ARCH" \
       --disk path=$_vdi,format=qcow2,bus=${VM_DISK:-virtio} \
+      --xml ./devices/disk[1]/driver/@discard=unmap \
+      --xml ./devices/disk[1]/driver/@detect_zeroes=unmap \
       --cdrom $_iso \
       --os-variant=$_ostype \
       --network network=default,model=${VM_NIC:-e1000} \
@@ -160,6 +164,8 @@ createVM() {
       --arch "$VM_ARCH" \
       --disk $_iso \
       --disk path=$_vdi,format=qcow2,bus=${VM_DISK:-virtio} \
+      --xml ./devices/disk[2]/driver/@discard=unmap \
+      --xml ./devices/disk[2]/driver/@detect_zeroes=unmap \
       --os-variant=$_ostype \
       --network network=default,model=${VM_NIC:-e1000} \
       --graphics vnc,listen=0.0.0.0 \
@@ -172,6 +178,8 @@ createVM() {
       --vcpus ${VM_CPU:-2} \
       --arch "$VM_ARCH" \
       --disk path=$_vdi,format=qcow2,bus=${VM_DISK:-virtio} \
+      --xml ./devices/disk[1]/driver/@discard=unmap \
+      --xml ./devices/disk[1]/driver/@detect_zeroes=unmap \
       --cdrom $_iso \
       --os-variant=$_ostype \
       --network network=default,model=${VM_NIC:-e1000} \
@@ -188,6 +196,8 @@ createVM() {
       --arch "$VM_ARCH" \
       --disk $_iso \
       --disk path=$_vdi,format=qcow2,bus=${VM_DISK:-virtio} \
+      --xml ./devices/disk[2]/driver/@discard=unmap \
+      --xml ./devices/disk[2]/driver/@detect_zeroes=unmap \
       --os-variant=$_ostype \
       --network network=default,model=${VM_NIC:-e1000} \
       --graphics vnc,listen=0.0.0.0 \
@@ -200,6 +210,8 @@ createVM() {
       --vcpus ${VM_CPU:-1} \
       --arch "$VM_ARCH" \
       --disk path=$_vdi,format=qcow2,bus=${VM_DISK:-virtio} \
+      --xml ./devices/disk[1]/driver/@discard=unmap \
+      --xml ./devices/disk[1]/driver/@detect_zeroes=unmap \
       --cdrom $_iso \
       --os-variant=$_ostype \
       --network network=default,model=${VM_NIC:-e1000} \
@@ -214,6 +226,8 @@ createVM() {
     --vcpus ${VM_CPU:-2} \
     --arch ${VM_ARCH:-x86_64} \
     --disk path=$_vdi,format=qcow2,bus=${VM_DISK:-virtio} \
+    --xml ./devices/disk[1]/driver/@discard=unmap \
+    --xml ./devices/disk[1]/driver/@detect_zeroes=unmap \
     --cdrom $_iso \
     --os-variant=$_ostype \
     --network network=default,model=${VM_NIC:-e1000} \


### PR DESCRIPTION
This will cause the disk driver to detect writes of zero blocks without using any underlying storage, preventing growth of the intermediate image when zeroing unused space.

Should fix the issue noted in https://github.com/anyvm-org/vbox/pull/7.

A test run for OpenBSD 7.8 amd64 here: https://github.com/daztucker/openbsd-builder/actions/runs/23641484546/job/68863027754
shows the intermediate openbsd.qcow2 as 3.5G,  openbsd-7.8.qcow2 post `qemu convert` as 2.3G and openbsd-7.8.qcow2.zst as 605M.  The other platforms are still running, but all of the VMs are running, which would be my primary concern with the change.

I'd be tempted to factor out those long virt-install command lines, but that would be a larger change.  Let me know if you'd like that.